### PR TITLE
void-ed unused function parameters

### DIFF
--- a/cores/stm32l4/CDC.cpp
+++ b/cores/stm32l4/CDC.cpp
@@ -41,6 +41,8 @@ extern int (*stm32l4_stdio_put)(char, FILE*);
 
 static int serialusb_stdio_put(char data, FILE *fp)
 {
+    (void)fp;
+
     return Serial.write(&data, 1);
 }
 
@@ -77,6 +79,9 @@ void CDC::begin(unsigned long baudrate)
 
 void CDC::begin(unsigned long baudrate, uint16_t config)
 {
+    (void)baudrate;
+    (void)config;
+
     /* If USBD_CDC has already been enabled/initialized by STDIO, just add the notify.
      */
     if (_usbd_cdc->state == USBD_CDC_STATE_INIT) {

--- a/cores/stm32l4/stm32l4_wiring_analog.c
+++ b/cores/stm32l4/stm32l4_wiring_analog.c
@@ -48,6 +48,7 @@ static uint8_t _writeCalibrate = 3;
 
 void analogReference(eAnalogReference reference)
 {
+    (void)reference;
 }
 
 void analogReadResolution(int resolution)

--- a/cores/stm32l4/stm32l4_wiring_tone.c
+++ b/cores/stm32l4/stm32l4_wiring_tone.c
@@ -37,6 +37,9 @@ static stm32l4_timer_t stm32l4_tone;
 
 static void tone_event_callback(void *context, uint32_t events)
 {
+    (void)context;
+    (void)events;
+
     if (toneCount) {
       if (toneGPIO->ODR & toneBit) {
 	    toneGPIO->BRR = toneBit;


### PR DESCRIPTION
Using (void)param eliminates unused-parameter warnings generated by gcc on Linux.