### PR TITLE
fix SPI.setBitOrder()

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -160,6 +160,7 @@ void SPIClass::setBitOrder(BitOrder bitOrder)
     
 	_selected = false;
     }
+	_bitOrder = bitOrder;
 }
 
 void SPIClass::setDataMode(uint8_t dataMode)


### PR DESCRIPTION
fixes SPI.setBitOrder() not responding to MSB or LSB setting.