### PR TITLE
Fixed a one byte typo in the top-level README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 
 ## Recovering from a faulty sketch for Tlera Corp Boards
 
- Sometimes a faulty sketch can render the normal USB Serial based integration into the Arduindo IDE not working. In this case plugin the STM32L4 board and toggle the RESET button while holding down the BOOT button and program a known to be working sketch to go ack to a working USB Serial setup.
+ Sometimes a faulty sketch can render the normal USB Serial based integration into the Arduindo IDE not working. In this case plugin the STM32L4 board and toggle the RESET button while holding down the BOOT button and program a known to be working sketch to go back to a working USB Serial setup.
 
 ## Credits
 


### PR DESCRIPTION
to go ack to -> to go back to.